### PR TITLE
Update ApplicationStatisticsStorage.java

### DIFF
--- a/dubbokeeper-storage/mysql-storage/src/main/java/com/dubboclub/dk/storage/mysql/ApplicationStatisticsStorage.java
+++ b/dubbokeeper-storage/mysql-storage/src/main/java/com/dubboclub/dk/storage/mysql/ApplicationStatisticsStorage.java
@@ -80,8 +80,12 @@ public class ApplicationStatisticsStorage  extends AbstractApplicationStatistics
             ApplicationInfo applicationInfo = new ApplicationInfo();
             applicationInfo.setApplicationName(application);
             applicationInfo.setApplicationType(type);
-            this.applicationMapper.addApplication(applicationInfo);
-            createNewAppTable(application);
+            try {
+                this.applicationMapper.addApplication(applicationInfo);
+                createNewAppTable(application);
+            } catch(DuplicateKeyException e) {
+                e.printStackTrace();
+            }
         }
         init();
         this.type=type;


### PR DESCRIPTION
#82 

当多实例的时候，同时往application表插数据（this.applicationMapper.addApplication(applicationInfo); ）导致DuplicateKeyException异常。增加异常处理，当出现该异常的时候，直接跳过。

